### PR TITLE
Updated library import for new Empire 4.0 server directory structure

### DIFF
--- a/plugins/socksproxyserver.py
+++ b/plugins/socksproxyserver.py
@@ -1,7 +1,12 @@
 from __future__ import print_function
+import importlib
 
-from empire.server.common.plugins import Plugin
-import empire.server.common.helpers as helpers
+if importlib.util.find_spec("empire") is not None:
+    from empire.server.common.plugins import Plugin
+    import empire.server.common.helpers as helpers    
+else:
+    from lib.common.plugins import Plugin
+    import lib.common.helpers as helpers    
 
 import socket
 import _thread

--- a/plugins/socksproxyserver.py
+++ b/plugins/socksproxyserver.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 
-from lib.common.plugins import Plugin
-import lib.common.helpers as helpers
+from empire.server.common.plugins import Plugin
+import empire.server.common.helpers as helpers
 
 import socket
 import _thread


### PR DESCRIPTION
The socksproxyserver plugin was crashing with the new Empire 4.0 directory structure. This code fixes the directory structure for using with version 4.0